### PR TITLE
Dev survey submit api client v2

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,7 +75,7 @@ import { TestsDataService } from './services/tests-data.service';
 import { MyAccountComponent } from './my-account/my-account.component';
 import { CustomerSearchComponent } from './customer-search/customer-search.component';
 
-import { SurveySubmitHandler } from './services/submit-survey/api-survey.submit.service';
+import { SurveySubmitHandler } from './services/api-survey.submit.service';
 
 // Application wide providers
 const APP_PROVIDERS = [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,6 +75,8 @@ import { TestsDataService } from './services/tests-data.service';
 import { MyAccountComponent } from './my-account/my-account.component';
 import { CustomerSearchComponent } from './customer-search/customer-search.component';
 
+import { SurveySubmitHandler } from './services/submit-survey/api-survey.submit.service';
+
 // Application wide providers
 const APP_PROVIDERS = [
   ...APP_RESOLVER_PROVIDERS,
@@ -163,7 +165,8 @@ type StoreType = {
     ThsStateflowService,
     ThsDataService,
     RouterGuards,
-    TestsDataService
+    TestsDataService,
+    SurveySubmitHandler
   ]
 })
 export class AppModule {

--- a/src/app/audiogram/audiogram.component.ts
+++ b/src/app/audiogram/audiogram.component.ts
@@ -58,7 +58,7 @@ export class AudiogramComponent implements OnInit {
   }
   public severityChange(event: MatRadioChange) {
     let sevs: Array<string> = ['leftHighSev', 'leftLowSev', 'rightHighSev', 'rightLowSev'];
-    if(sevs.includes(event.source.name)) {
+    if(sevs.indexOf(event.source.name) > -1) {
       this.dataService.saveData(sevs[sevs.indexOf(event.source.name)], event.value);
     }
   }

--- a/src/app/audiogram/audiogram.component.ts
+++ b/src/app/audiogram/audiogram.component.ts
@@ -58,7 +58,7 @@ export class AudiogramComponent implements OnInit {
   }
   public severityChange(event: MatRadioChange) {
     let sevs: Array<string> = ['leftHighSev', 'leftLowSev', 'rightHighSev', 'rightLowSev'];
-    if(sevs.indexOf(event.source.name) > -1) {
+    if(sevs.includes(event.source.name)) {
       this.dataService.saveData(sevs[sevs.indexOf(event.source.name)], event.value);
     }
   }

--- a/src/app/audiologist-navigation/audiologist-navigation.component.html
+++ b/src/app/audiologist-navigation/audiologist-navigation.component.html
@@ -32,11 +32,12 @@
         <button type="submit"><i class="fa fa-search"></i></button>
       </div>
 
-      <div class="row"><label class="sec-label">TESTS</label></div>
-      <div class="row"><button class="main-btn" (click)="showRecommendedTests()">Recommended</button></div>
-      <!-- <div class="row"><button class="main-btn" (click)="showSuggestedTests()">Suggested</button></div> -->
-      <div class="row"><label class="sec-label">SUMMARY SECTION</label></div>
-      <div class="row"><button class="main-btn" (click)="showSummary()">Summary</button></div>
+    <div class="row"><label class="sec-label">TESTS</label></div>
+    <div class="row"><button class="main-btn" (click)="showRecommendedTests()">Recommended</button></div>
+    <!-- <div class="row"><button class="main-btn" (click)="showSuggestedTests()">Suggested</button></div> -->
+    <div class="row"><label class="sec-label">SUMMARY SECTION</label></div>
+    <div class="row"><button class="main-btn" (click)="showSummary()">Summary</button></div>
+    <div class="row"><button class="main-btn" (click)="submitSurvey()">Submit</button></div>
 
     </div>
     <div class="{{active ? 'right-container' : 'right-container-full'}}">

--- a/src/app/audiologist-navigation/audiologist-navigation.component.ts
+++ b/src/app/audiologist-navigation/audiologist-navigation.component.ts
@@ -1,8 +1,9 @@
 import { ActivatedRouteSnapshot } from '@angular/router';
-import { Component, ViewEncapsulation } from '@angular/core';
+import { ViewChild, Component, ViewEncapsulation } from '@angular/core';
 import { aggregateBy } from '@progress/kendo-data-query';
 import { NgForm } from '@angular/forms';
 import { SurveySubmitHandler } from '../services/api-survey.submit.service';
+import { AudiologistSummaryComponent } from '../audiologist-summary/audiologist-summary.component';
 import { Utilities } from '../common/utlilities';
 
 @Component({
@@ -17,6 +18,8 @@ import { Utilities } from '../common/utlilities';
  * active: boolean is a local variable will be switch between true and false to trigger the function.
  */
 export class AudiologistNavigationComponent {
+    @ViewChild(AudiologistSummaryComponent) summaryComponent : AudiologistSummaryComponent;
+
     public active: boolean = true;
     public scale: number = 0.55;
     public recommendedTests: boolean = false;
@@ -52,7 +55,11 @@ export class AudiologistNavigationComponent {
     }
 
     public submitSurvey() {
-      let surveySubmitHandler = new SurveySubmitHandler();
-      surveySubmitHandler.submitSurvey();
+      if(this.summaryComponent != null) {
+        this.summaryComponent.submitSurvey();
+      }
+
+      //let surveySubmitHandler = new SurveySubmitHandler();
+      //surveySubmitHandler.submitSurvey();
     }
 }

--- a/src/app/audiologist-navigation/audiologist-navigation.component.ts
+++ b/src/app/audiologist-navigation/audiologist-navigation.component.ts
@@ -52,10 +52,7 @@ export class AudiologistNavigationComponent {
     }
 
     public submitSurvey() {
-      alert('Survey Submitted!');
       let surveySubmitHandler = new SurveySubmitHandler();
-      let squanto = Utilities.getSessionStorage('tests-data');
-      console.log(squanto);
-      console.log(surveySubmitHandler.print());
+      surveySubmitHandler.submitSurvey();
     }
 }

--- a/src/app/audiologist-navigation/audiologist-navigation.component.ts
+++ b/src/app/audiologist-navigation/audiologist-navigation.component.ts
@@ -2,6 +2,8 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 import { Component, ViewEncapsulation } from '@angular/core';
 import { aggregateBy } from '@progress/kendo-data-query';
 import { NgForm } from '@angular/forms';
+import { SurveySubmitHandler } from '../services/api-survey.submit.service';
+import { Utilities } from '../common/utlilities';
 
 @Component({
   selector: 'audio-navigation',
@@ -20,6 +22,7 @@ export class AudiologistNavigationComponent {
     public recommendedTests: boolean = false;
     public suggestedTests: boolean = false;
     public summary: boolean = true;
+
     public onToggle() {
       if (!this.active) {
           this.active = true;
@@ -46,5 +49,13 @@ export class AudiologistNavigationComponent {
       this.recommendedTests = false;
       this.suggestedTests = false;
       this.summary = true;
+    }
+
+    public submitSurvey() {
+      alert('Survey Submitted!');
+      let surveySubmitHandler = new SurveySubmitHandler();
+      let squanto = Utilities.getSessionStorage('tests-data');
+      console.log(squanto);
+      console.log(surveySubmitHandler.print());
     }
 }

--- a/src/app/audiologist-navigation/audiologist-navigation.component.ts
+++ b/src/app/audiologist-navigation/audiologist-navigation.component.ts
@@ -2,7 +2,6 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 import { ViewChild, Component, ViewEncapsulation } from '@angular/core';
 import { aggregateBy } from '@progress/kendo-data-query';
 import { NgForm } from '@angular/forms';
-import { SurveySubmitHandler } from '../services/api-survey.submit.service';
 import { AudiologistSummaryComponent } from '../audiologist-summary/audiologist-summary.component';
 import { Utilities } from '../common/utlilities';
 
@@ -59,7 +58,5 @@ export class AudiologistNavigationComponent {
         this.summaryComponent.submitSurvey();
       }
 
-      //let surveySubmitHandler = new SurveySubmitHandler();
-      //surveySubmitHandler.submitSurvey();
     }
 }

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -53,7 +53,13 @@ export class AudiologistSummaryComponent implements OnInit {
 
   public submitSurvey() {
     let surveySubmitHandler = new SurveySubmitHandler();
-    surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars, this.ts);
+
+    try {
+      surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars, this.ts);
+      alert('Survey submitted!');
+    }  catch(e) {
+      alert(e);
+    }
   }
 
   //////////////

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit} from '@angular/core';
 import { Utilities } from '../common/utlilities';
 import { ThsDataService } from '../services/ths-data.service';
 import { TsScreenerDataService } from '../services/ts-screener-data.service';
@@ -48,6 +48,10 @@ export class AudiologistSummaryComponent implements OnInit {
 
   public ngOnInit() {
     this.subscription = this.testsDataService.observableData.subscribe(data => this.updateTestResults(data));
+  }
+
+  public submitSurvey() {
+    console.log('Survey submitted!');
   }
 
   //////////////

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -52,10 +52,8 @@ export class AudiologistSummaryComponent implements OnInit {
   }
 
   public submitSurvey() {
-    console.log('Survey submitted!');
-
-      let surveySubmitHandler = new SurveySubmitHandler();
-      surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars);
+    let surveySubmitHandler = new SurveySubmitHandler();
+    surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars);
   }
 
   //////////////

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -6,6 +6,7 @@ import { TfiDataService } from '../services/tfi-data.service';
 import { TsScreenerAnswerStrings, ThsAnswerStrings } from '../common/custom-resource-strings';
 import { TestsDataService } from '../services/tests-data.service';
 import { Subscription } from 'rxjs/Subscription';
+import { SurveySubmitHandler } from '../services/api-survey.submit.service';
 
 const tfiNames: string[] = ['overallTFI', 'intrusive', 'sense', 'cognitive', 'sleep', 'auditory', 'relaxation', 'quality', 'emotional'];
 const testRadioNames: string[] = ['audiogramType', 'leftHighSev', 'leftLowSev', 'rightHighSev', 'rightLowSev', 'otoscopyType', 'tympanometryType'];
@@ -52,6 +53,9 @@ export class AudiologistSummaryComponent implements OnInit {
 
   public submitSurvey() {
     console.log('Survey submitted!');
+
+      let surveySubmitHandler = new SurveySubmitHandler();
+      surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars);
   }
 
   //////////////

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -53,7 +53,7 @@ export class AudiologistSummaryComponent implements OnInit {
 
   public submitSurvey() {
     let surveySubmitHandler = new SurveySubmitHandler();
-    surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars);
+    surveySubmitHandler.submitSurvey(this.thsScoreVars, this.tfiVars, this.ts);
   }
 
   //////////////

--- a/src/app/audiologist-summary/audiologist-summary.component.ts
+++ b/src/app/audiologist-summary/audiologist-summary.component.ts
@@ -158,7 +158,7 @@ export class AudiologistSummaryComponent implements OnInit {
     }
     for (let dat in data) {
       if (data.hasOwnProperty(dat)) {
-        if(testRadioNames.includes(data[dat].name)) {
+        if(testRadioNames.indexOf(data[dat].name) > -1) {
           this.testRadioVars.set(data[dat].name, data[dat].value);
         }
       }

--- a/src/app/services/api-survey.submit.service.spec.ts
+++ b/src/app/services/api-survey.submit.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { SurveySubmitHandler } from './api-survey.submit.service.ts';
+
+describe('SurveySubmitHandler', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SurveySubmitHandler]
+    });
+  });
+
+  it('should be created', inject([SurveySubmitHandler], (service: SurveySubmitHandler) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should print name', inject([SurveySubmitHandler], (service: SurveySubmitHandler) => {
+    expect(service.print()).toBe('Test');
+  }));
+});

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@angular/core';
+import { Utilities } from '../common/utlilities';
 
 @Injectable()
 export class SurveySubmitHandler {
-  constructor() {
-    console.log('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH');
-  }
+  public submitSurvey() : boolean {
+    alert('Did submission!');
+    let testData = Utilities.getSessionStorage('tests-data');
 
-  public print() : string {
-    return 'Test';
+    if(testData == null) {
+      console.log('No test data!');
+      return false;
+    }
+
+    console.log(testData);
+    return false;
   }
 }

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Utilities } from '../common/utlilities';
 
 class PatientJSON {
-  patienID : number = 0;
+  patienID : string = '';
   isDeceased : boolean = false;
 }
 
@@ -72,14 +72,9 @@ export class SurveySubmitHandler {
     result.patientSurvey = this.buildPatientSurveyJSON(testData, thsScoreVars, tfiVars);
     result.patient = new PatientJSON;
 
-    if(this.getPropertyValue(testData, 'audiogramType') !== '') {
-      console.log('Got the value!');
-    } else {
-      console.log('Did not get the value!');
-    }
+    result.patient.patienID = Utilities.getSessionStorage('patient-id');
 
-    console.log(testData);
-    //console.log(JSON.stringify(result));
+    console.log(JSON.stringify(result));
     return true;
   }
 

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -54,7 +54,6 @@ export class SurveySubmitHandler {
   // Note that anything passed in here is data that is not
   // accessible via session storage.
   public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>) : boolean {
-    alert('Did submission!');
     let testDataString = Utilities.getSessionStorage('tests-data');
 
     if(testDataString == null) {

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -53,10 +53,13 @@ class SurveyInstanceJSON {
 export class SurveySubmitHandler {
   // Note that anything passed in here is data that is not
   // accessible via session storage.
-  public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>, tsType : string) : boolean {
+  public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>, tsType : string) {
     if(thsScoreVars == null) {
-      console.log('SUBMISSION FAILED: NO THS SCORE DATA');
-      return false;
+      throw new Error('No THS Score Data');
+    }
+
+    if(tsType == null || tsType === '') {
+      throw new Error('Unknown TS Type');
     }
 
     let testDataString = Utilities.getSessionStorage('tests-data');
@@ -64,21 +67,21 @@ export class SurveySubmitHandler {
 
     let result = new SurveyInstanceJSON;
     result.patientSurvey = this.buildPatientSurveyJSON(testData, thsScoreVars, tfiVars, tsType);
-
-    // TODO: Refactor patient creation into its own method!
     result.patient = this.buildPatientJSON();
 
+    if(result.patientSurvey == null) {
+      throw new Error('Failed to build patient survey. Either no survey data, or ts type is unknown');
+    }
+
     if(result.patient == null) {
-      console.log('SUBMISSION FAILED: Could not get patient information!');
-      return false;
+      throw new Error('No patient data');
     }
 
     console.log(JSON.stringify(result));
-    return true;
   }
 
   buildPatientSurveyJSON(testData, thsScoreVars : Map<string, number>, tfiVars : Map<string, number>, tsType : string) : PatientSurveyJSON {
-    if(thsScoreVars == null || tsType == null) {
+    if(thsScoreVars == null || tsType == null || tsType == '') {
       return null;
     }
 

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -94,22 +94,71 @@ export class SurveySubmitHandler {
 
     result.rightEarHighFreqSeverity = this.getPropertyValue(testData, 'rightHighSev');
     result.rightEarLowFreqSeverity = this.getPropertyValue(testData, 'rightLowSev');
+    result.rightEarHighFreqConfiguration = this.buildFreqConfig(testData, 'rightHigh');
+    result.rightEarLowFreqConfiguration = this.buildFreqConfig(testData, 'rightLow');
 
     result.leftEarHighFreqSeverity = this.getPropertyValue(testData, 'leftHighSev');
     result.leftEarLowFreqSeverity = this.getPropertyValue(testData, 'leftLowSev');
-    result.leftEarHighFreqConfiguration = this.buildLeftHighFreqConfig(testData);
+    result.leftEarHighFreqConfiguration = this.buildFreqConfig(testData, 'leftHigh');
+    result.leftEarLowFreqConfiguration = this.buildFreqConfig(testData, 'leftLow');
 
     console.log(result);
 
     return result;
   }
 
-  buildLeftHighFreqConfig(testData) : string {
+  buildFreqConfig(testData, configType : string) : string {
     let result : string = '';
 
-    let symmetric = this.getPropertyValue(testData, 'leftHighConfigSymmetric');
-    if(symmetric !== '' && symmetric != 'false') {
+    let symmetric = this.getPropertyValue(testData, configType + 'ConfigSymmetric');
+    let asymmetric = this.getPropertyValue(testData, configType + 'ConfigAsymmetric');
+    let progressive = this.getPropertyValue(testData, configType + 'ConfigProgressive');
+    let sudden = this.getPropertyValue(testData, configType + 'ConfigSudden');
+    let flat = this.getPropertyValue(testData, configType + 'ConfigFlat');
+    let rising  = this.getPropertyValue(testData, configType + 'ConfigRising');
+    let cookieBite = this.getPropertyValue(testData, configType + 'ConfigCookie Bite');
+    let precipitous = this.getPropertyValue(testData, configType + 'ConfigPrecipitous');
+    let noiseNotch = this.getPropertyValue(testData, configType + 'ConfigNoise-Notch');
+    let corner = this.getPropertyValue(testData, configType + 'ConfigCorner');
+
+    if(symmetric !== '' && symmetric !== 'false') {
       result = (result.concat('Symmetric')).concat(';');
+    }
+
+    if(asymmetric !== '' && asymmetric !== 'false') {
+      result = (result.concat('Asymmetric')).concat(';');
+    }
+
+    if(progressive !== '' && progressive !== 'false') {
+      result = (result.concat('Progressive')).concat(';');
+    }
+
+    if(sudden != '' && sudden !== 'false') {
+      result = (result.concat('Sudden')).concat(';');
+    }
+
+    if(flat != '' && flat !== 'false') {
+      result = (result.concat('Flat')).concat(';');
+    }
+
+    if(rising != '' && rising !== 'false') {
+      result = (result.concat('Rising')).concat(';');
+    }
+
+    if(cookieBite != '' && cookieBite !== 'false') {
+      result = (result.concat('CookieBite')).concat(';');
+    }
+
+    if(precipitous != '' && precipitous !== 'false') {
+      result = (result.concat('Precipitous')).concat(';');
+    }
+
+    if(noiseNotch != '' && noiseNotch !== 'false') {
+      result = (result.concat('NoiseNotch')).concat(';');
+    }
+
+    if(corner != '' && corner !== 'false') {
+      result = (result.concat('Corner')).concat(';');
     }
 
     return result;

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -62,8 +62,12 @@ export class SurveySubmitHandler {
 
     let testData = JSON.parse(testDataString);
 
+    if(testData == null) {
+      return false;
+    }
+
     let result = new SurveyInstanceJSON;
-    result.patientSurvey = new PatientSurveyJSON;
+    result.patientSurvey = this.buildPatientSurveyJSON(testData);
     result.patient = new PatientJSON;
 
     if(this.getPropertyValue(testData, 'audiogramType') !== '') {
@@ -73,8 +77,42 @@ export class SurveySubmitHandler {
     }
 
     console.log(testData);
-    console.log(JSON.stringify(result));
-    return false;
+    //console.log(JSON.stringify(result));
+    return true;
+  }
+
+  buildPatientSurveyJSON(testData) : PatientSurveyJSON {
+    if(testData == null)
+      return null;
+
+    let result : PatientSurveyJSON = new PatientSurveyJSON;
+
+    result.audiogram = this.getPropertyValue(testData, 'audiogramType');
+
+    result.otoscopy = this.getPropertyValue(testData, 'otoscopyType');
+    result.typanometry = this.getPropertyValue(testData, 'tympanometryType');
+
+    result.rightEarHighFreqSeverity = this.getPropertyValue(testData, 'rightHighSev');
+    result.rightEarLowFreqSeverity = this.getPropertyValue(testData, 'rightLowSev');
+
+    result.leftEarHighFreqSeverity = this.getPropertyValue(testData, 'leftHighSev');
+    result.leftEarLowFreqSeverity = this.getPropertyValue(testData, 'leftLowSev');
+    result.leftEarHighFreqConfiguration = this.buildLeftHighFreqConfig(testData);
+
+    console.log(result);
+
+    return result;
+  }
+
+  buildLeftHighFreqConfig(testData) : string {
+    let result : string = '';
+
+    let symmetric = this.getPropertyValue(testData, 'leftHighConfigSymmetric');
+    if(symmetric !== '' && symmetric != 'false') {
+      result = (result.concat('Symmetric')).concat(';');
+    }
+
+    return result;
   }
 
   getPropertyValue(testData, property : string) : string {
@@ -93,12 +131,5 @@ export class SurveySubmitHandler {
     }
 
     return result;
-  }
-
-  printTestDataNames(testData) {
-    let i : number;
-    for(i = 0; i < testData.length; i++) {
-      console.log(testData[i]['name']);
-    }
   }
 }

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -53,7 +53,7 @@ class SurveyInstanceJSON {
 export class SurveySubmitHandler {
   // Note that anything passed in here is data that is not
   // accessible via session storage.
-  public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>) : boolean {
+  public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>, tsType : string) : boolean {
     if(thsScoreVars == null) {
       console.log('SUBMISSION FAILED: NO THS SCORE DATA');
       return false;
@@ -63,7 +63,7 @@ export class SurveySubmitHandler {
     let testData = JSON.parse(testDataString);
 
     let result = new SurveyInstanceJSON;
-    result.patientSurvey = this.buildPatientSurveyJSON(testData, thsScoreVars, tfiVars);
+    result.patientSurvey = this.buildPatientSurveyJSON(testData, thsScoreVars, tfiVars, tsType);
 
     // TODO: Refactor patient creation into its own method!
     result.patient = this.buildPatientJSON();
@@ -77,12 +77,14 @@ export class SurveySubmitHandler {
     return true;
   }
 
-  buildPatientSurveyJSON(testData, thsScoreVars : Map<string, number>, tfiVars : Map<string, number>) : PatientSurveyJSON {
-    if(thsScoreVars == null) {
+  buildPatientSurveyJSON(testData, thsScoreVars : Map<string, number>, tfiVars : Map<string, number>, tsType : string) : PatientSurveyJSON {
+    if(thsScoreVars == null || tsType == null) {
       return null;
     }
 
     let result : PatientSurveyJSON = new PatientSurveyJSON;
+
+    result.tsTinnitusType = tsType;
 
     // Although we recieve a boolean value, we do not care about its
     // result since the recommended test data does not need to exist for

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Utilities } from '../common/utlilities';
 
-// TODO: Better name for this!
 class PatientJSON {
   patienID : number = 0;
   isDeceased : boolean = false;
@@ -54,16 +53,52 @@ class SurveyInstanceJSON {
 export class SurveySubmitHandler {
   public submitSurvey() : boolean {
     alert('Did submission!');
-    let testData = Utilities.getSessionStorage('tests-data');
+    let testDataString = Utilities.getSessionStorage('tests-data');
 
-    if(testData == null) {
+    if(testDataString == null) {
       console.log('No test data!');
       return false;
     }
 
-    console.log(testData);
+    let testData = JSON.parse(testDataString);
+
     let result = new SurveyInstanceJSON;
+    result.patientSurvey = new PatientSurveyJSON;
+    result.patient = new PatientJSON;
+
+    if(this.getPropertyValue(testData, 'audiogramType') !== '') {
+      console.log('Got the value!');
+    } else {
+      console.log('Did not get the value!');
+    }
+
+    console.log(testData);
     console.log(JSON.stringify(result));
     return false;
+  }
+
+  getPropertyValue(testData, property : string) : string {
+    if(testData == null || testData.length < 1) {
+      return '';
+    }
+
+    let result : string = '';
+
+    let i : number;
+    for(i = 0; i < testData.length; i++) {
+      if(testData[i]['name'] === property) {
+        result = testData[i]['value'];
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  printTestDataNames(testData) {
+    let i : number;
+    for(i = 0; i < testData.length; i++) {
+      console.log(testData[i]['name']);
+    }
   }
 }

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -1,6 +1,55 @@
 import { Injectable } from '@angular/core';
 import { Utilities } from '../common/utlilities';
 
+// TODO: Better name for this!
+class PatientJSON {
+  patienID : number = 0;
+  isDeceased : boolean = false;
+}
+
+class PatientSurveyJSON {
+    otoscopy : string = '';
+    typanometry : string = '';
+
+
+    rightEarLowFreqSeverity : string = '';
+    rightEarLowFreqConfiguration : string = '';
+    rightEarHighFreqSeverity : string = '';
+    rightEarHighFreqConfiguration : string = '';
+
+    leftEarLowFreqSeverity : string = '';
+    leftEarLowFreqConfiguration : string = '';
+    leftEarHighFreqSeverity : string = '';
+    leftEarHighFreqConfiguration : string = '';
+
+    audiogram : string = '';
+
+
+    thsSectionATotal : number = 0;
+    thsSectionBTotal : number = 0;
+    thsSectionCSeverity : string = '';
+
+
+    tfiI : number = 0;
+    tfiSc : number = 0;
+    tfiC : number = 0;
+    tfiSi : number = 0;
+    tfiA : number = 0;
+    tfiR : number = 0;
+    tfiQ : number = 0;
+    tfiE : number = 0;
+
+    tfiOverallScore : number = 0;
+
+
+    tsTinnitusType : string = '';
+}
+
+class SurveyInstanceJSON {
+  patientSurvey : PatientSurveyJSON;
+  patient : PatientJSON;
+}
+
 @Injectable()
 export class SurveySubmitHandler {
   public submitSurvey() : boolean {
@@ -13,6 +62,8 @@ export class SurveySubmitHandler {
     }
 
     console.log(testData);
+    let result = new SurveyInstanceJSON;
+    console.log(JSON.stringify(result));
     return false;
   }
 }

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -26,7 +26,7 @@ class PatientSurveyJSON {
 
     thsSectionATotal : number = 0;
     thsSectionBTotal : number = 0;
-    thsSectionCSeverity : string = '';
+    thsSectionCSeverity : number = 0;
 
 
     tfiI : number = 0;
@@ -51,7 +51,9 @@ class SurveyInstanceJSON {
 
 @Injectable()
 export class SurveySubmitHandler {
-  public submitSurvey() : boolean {
+  // Note that anything passed in here is data that is not
+  // accessible via session storage.
+  public submitSurvey(thsScoreVars : Map<string, number>, tfiVars : Map<string, number>) : boolean {
     alert('Did submission!');
     let testDataString = Utilities.getSessionStorage('tests-data');
 
@@ -67,7 +69,7 @@ export class SurveySubmitHandler {
     }
 
     let result = new SurveyInstanceJSON;
-    result.patientSurvey = this.buildPatientSurveyJSON(testData);
+    result.patientSurvey = this.buildPatientSurveyJSON(testData, thsScoreVars, tfiVars);
     result.patient = new PatientJSON;
 
     if(this.getPropertyValue(testData, 'audiogramType') !== '') {
@@ -81,7 +83,7 @@ export class SurveySubmitHandler {
     return true;
   }
 
-  buildPatientSurveyJSON(testData) : PatientSurveyJSON {
+  buildPatientSurveyJSON(testData, thsScoreVars : Map<string, number>, tfiVars : Map<string, number>) : PatientSurveyJSON {
     if(testData == null)
       return null;
 
@@ -102,7 +104,19 @@ export class SurveySubmitHandler {
     result.leftEarHighFreqConfiguration = this.buildFreqConfig(testData, 'leftHigh');
     result.leftEarLowFreqConfiguration = this.buildFreqConfig(testData, 'leftLow');
 
-    console.log(result);
+    result.thsSectionATotal = thsScoreVars.get("thsA");
+    result.thsSectionBTotal = thsScoreVars.get("thsB");
+    result.thsSectionCSeverity = thsScoreVars.get("thsC");
+
+    result.tfiI = tfiVars.get("intrusive");
+    result.tfiSc = tfiVars.get("sense");
+    result.tfiC = tfiVars.get("cognitive");
+    result.tfiSi = tfiVars.get("sleep");
+    result.tfiA = tfiVars.get("auditory");
+    result.tfiR = tfiVars.get("relaxation");
+    result.tfiQ = tfiVars.get("quality");
+    result.tfiE = tfiVars.get("emotional");
+    result.tfiOverallScore = tfiVars.get("overallTFI");
 
     return result;
   }

--- a/src/app/services/api-survey.submit.service.ts
+++ b/src/app/services/api-survey.submit.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class SurveySubmitHandler {
+  constructor() {
+    console.log('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH');
+  }
+
+  public print() : string {
+    return 'Test';
+  }
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the client side for submitting a survey (mainly creates a JSON object of all the relevent survey data).


* **What is the current behavior?** (You can also link to an open issue here)
Survey data is only stored in session storage and other places locally.


* **What is the new behavior (if this is a feature change)?**
The survey and tests data is compiled into a JSON object that can then be sent to the server-side to be stored.


* **Other information**:
IT DOES NOT SEND THE INFORMATION TO THE SERVER SIDE! The back end for this needs to be set up. But for the client, this is a matter of a function call I think.