### PR TITLE
Prevent error message while compiling client

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "strictNullChecks": false,
     "lib": [
       "dom",
-      "es6",
       "es7"
     ],
     "baseUrl": ".",

--- a/tsconfig.webpack.json
+++ b/tsconfig.webpack.json
@@ -12,8 +12,8 @@
     "importHelpers": true,
     "strictNullChecks": false,
     "lib": [
-      "es2015",
-      "dom"
+      "dom",
+      "es7"
     ],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
* Prevent `Property 'includes' does not exist on type 'string[]'.`
