### PR TITLE
Changed onInit to look at session storage for data.

### DIFF
--- a/client/src/app/patient-login/patient-login.component.ts
+++ b/client/src/app/patient-login/patient-login.component.ts
@@ -28,7 +28,7 @@ export class PatientLoginComponent implements OnInit {
   }
 
   public ngOnInit() {
-    let noData: boolean = this.tsDataService.dataRecord === null || this.tsDataService.dataRecord.length < 1;
+    let noData: boolean = Utilities.getSessionStorage('ts-dataRecord') === null || Utilities.getSessionStorage('ts-dataRecord').length < 1;
     let noID: boolean = Utilities.getSessionStorage('patient-id') === null || Utilities.getSessionStorage('patient-id').length < 1;
     if (noData || !noID) {
       this.router.navigateByUrl(this.nextURL);


### PR DESCRIPTION
Currently in development, when a session key times out and the user is prompted to re login. If the user refreshes the page before logging in, the client app 404's.

This PR is a fix for that issue so the app will reload properly (and properly prompt to re-login as well).